### PR TITLE
Expand the set of infrastructure tests and improve parametrisation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,23 +121,6 @@ jobs:
       - gcp_apply:
           dir: ./ops/cluster
 
-  test_infrastructure:
-    docker:
-      - image: << pipeline.parameters.ruby-image >>
-    steps:
-      - checkout
-      - set_branch
-      - gcp_key
-      - run:
-          name: Install InSpec
-          command: gem install inspec-bin -v << pipeline.parameters.inspec-version >>
-      - run:
-          name: Run InSpec
-          command: |
-            source ~/.env
-            cd ./ops/tests
-            inspec exec . -t gcp:// --chef-license=accept-no-persist --input gcp_project_id=$GOOGLE_PROJECT
-
   deploy_app:
     docker:
       - image: << pipeline.parameters.gcloud-image >>
@@ -160,6 +143,27 @@ jobs:
       - gcp_apply:
           dir: ./ops/ingress
 
+  test_infrastructure:
+    docker:
+      - image: << pipeline.parameters.ruby-image >>
+    steps:
+      - checkout
+      - set_branch
+      - gcp_key
+      - run:
+          name: Install InSpec
+          command: gem install inspec-bin -v << pipeline.parameters.inspec-version >>
+      - run:
+          name: Run InSpec
+          command: |
+            source ~/.env
+            cd ./ops/tests
+            inspec exec . -t gcp:// \
+                      --chef-license=accept-no-persist \
+                      --input gcp_project_id=$GOOGLE_PROJECT \
+                              gcp_region=$GOOGLE_REGION \
+                              gcp_zone=$GOOGLE_ZONE
+
   destroy:
     docker:
       - image: << pipeline.parameters.terraform-image >>
@@ -180,20 +184,20 @@ workflows:
       - apply_cluster:
           requires:
             - apply_network
-      - test_infrastructure:
-          requires:
-            - apply_cluster
       - deploy_app:
           requires:
             - apply_cluster
       - apply_ingress:
           requires:
-            - test_infrastructure
             - deploy_app
+      - test_infrastructure:
+          requires:
+            - apply_ingress
+
   down:
     triggers:
       - schedule:
-          cron: "0 1,4,7,10,13,16,19,22 * * *"
+          cron: "0 1,4,7,17 * * *"
           filters:
             branches:
               ignore: "master"

--- a/ops/bootstrap.sh
+++ b/ops/bootstrap.sh
@@ -58,7 +58,7 @@ echo
 echo "${START}Creating '${USER}' service account...${RESET}"
 gcloud iam service-accounts create ${USER} \
     --display-name="Infrastructure" \
-    --description="Service account is used to provision infrastructure during CI/CD"
+    --description="Service account used to provision infrastructure during CI/CD"
 echo "${COMPLETE}Service account created${RESET}"
 echo
 

--- a/ops/env/dev.tfvars
+++ b/ops/env/dev.tfvars
@@ -1,6 +1,6 @@
 gcp_registry="eu.gcr.io"
 app_cidr_range="10.2.0.0/16"
-machine_type="n1-standard-1"
+machine_type="n1-standard-2"
 min_node_count=1
-max_node_count=2
+max_node_count=1
 max_surge=1

--- a/ops/env/pub.tfvars
+++ b/ops/env/pub.tfvars
@@ -2,5 +2,5 @@ gcp_registry="eu.gcr.io"
 app_cidr_range="10.2.0.0/16"
 machine_type="n1-standard-2"
 min_node_count=1
-max_node_count=2
+max_node_count=1
 max_surge=1

--- a/ops/tests/.gitignore
+++ b/ops/tests/.gitignore
@@ -1,0 +1,1 @@
+inspec.lock

--- a/ops/tests/controls/cluster.rb
+++ b/ops/tests/controls/cluster.rb
@@ -1,11 +1,26 @@
-title "delineate.io Infrastructure Tests"
+title "delineate.io Platform Cluster Tests"
 
 gcp_project_id = attribute("gcp_project_id")
+gcp_zone = attribute("gcp_zone")
 
 control "app-cluster-1.0" do
   impact 1.0
-  title "Ensure application cluster is as expected"
-  describe google_container_cluster(project: gcp_project_id, location: 'europe-west2-a', name: 'app-cluster') do
+  title "Ensure cluster is as expected"
+
+  # External IP address is available
+  describe google_compute_global_address(project: gcp_project_id, name: 'app-cluster-ip') do
     it { should exist }
+    its('address_type') { should eq 'EXTERNAL' }
   end
+
+  describe google_container_clusters(project: gcp_project_id, location: gcp_zone) do
+    its('count') { should eq 1}
+  end
+
+  # Checks the cluster itself
+  describe google_container_cluster(project: gcp_project_id, location: gcp_zone, name: 'app-cluster') do
+    it { should exist }
+    its('status') { should eq 'RUNNING' }
+  end
+
 end

--- a/ops/tests/controls/network.rb
+++ b/ops/tests/controls/network.rb
@@ -1,0 +1,24 @@
+title "delineate.io Platform Network Tests"
+
+gcp_project_id = attribute("gcp_project_id")
+gcp_region = attribute("gcp_region")
+
+control "app-network-1.0" do
+  impact 1.0
+  title "Ensure network is as expected"
+
+  # Make sure the default network has been deleted
+  describe google_compute_network(project: gcp_project_id, name: 'default') do
+    it { should_not exist }
+  end
+
+  # Tests that the network is as expected
+  describe google_compute_network(project: gcp_project_id, name: 'app-network') do
+    it { should exist }
+    its ('auto_create_subnetworks'){ should be false }
+    its ('routing_config.routing_mode') { should eq "REGIONAL" }
+    its ('subnetworks.count') { should eq 1 }
+    its ('subnetworks.first') { should match "app-subnet-" + gcp_region}
+  end
+
+end

--- a/ops/tests/controls/storage.rb
+++ b/ops/tests/controls/storage.rb
@@ -1,0 +1,26 @@
+title "delineate.io Platform Storage Tests"
+
+gcp_project_id = attribute("gcp_project_id")
+gcp_region = attribute("gcp_region").upcase
+
+control "app-storage-1.0" do
+  impact 1.0
+  title "Ensure storage is as expected"
+
+  # Tests all buckets have the expected items
+  describe google_storage_buckets(project: gcp_project_id) do
+    its('count') { should eq 3 }
+  end
+
+  describe google_storage_bucket(name: gcp_project_id + '-tf') do
+    it { should exist }
+    its('location') { should eq gcp_region }
+  end
+
+  describe google_storage_bucket(name: gcp_project_id + '-deployments') do
+    it { should exist }
+    its('location') { should eq gcp_region }
+    its('versioning.enabled') { should eq true }
+  end
+
+end

--- a/vm/core/cli.yml
+++ b/vm/core/cli.yml
@@ -80,3 +80,4 @@
       name: inspec-bin
       version: 4.21.3
       state: present
+     become_user: vagrant


### PR DESCRIPTION
The main purpose of this commit was to expand the basic testing to cover the network & storage tests and some additional basic cluster tests.

There were challenges testing locally as the dev environment was not up and running.  Therefore the scheduling of the env destroy has been changed aligned to working patterns.