### PR TITLE
Fix some minor niggles of the jobs changes

### DIFF
--- a/ops/bootstrap/roles.txt
+++ b/ops/bootstrap/roles.txt
@@ -15,3 +15,5 @@ roles/cloudsql.admin
 roles/resourcemanager.projectIamAdmin
 roles/run.admin
 roles/cloudscheduler.admin
+roles/appengine.appAdmin
+roles/iam.roleAdmin

--- a/ops/cloud/cluster/cluster.tf
+++ b/ops/cloud/cluster/cluster.tf
@@ -62,7 +62,7 @@ resource "google_container_cluster" "app_cluster" {
   }
 
   lifecycle {
-    ignore_changes = ["master_auth"]
+    ignore_changes = [master_auth]
   }
 }
 

--- a/ops/cloud/jobs/cleaner.tf
+++ b/ops/cloud/jobs/cleaner.tf
@@ -54,7 +54,6 @@ resource "google_cloud_scheduler_job" "clean_job" {
   attempt_deadline = "360s"
 
   http_target {
-    headers     = {}
     http_method = "POST"
     uri         = "${google_cloud_run_service.clean_job.status[0].url}/http"
     body        = base64encode(templatefile("${path.module}/cleaner/config.json", { gcp_project = "${local.gcp_project}", gcp_registry = "${var.gcp_registry}" }))
@@ -65,7 +64,7 @@ resource "google_cloud_scheduler_job" "clean_job" {
     }
   }
 
-  timeouts {}
+  depends_on = [google_project_iam_member.infrastructure_app_engine_creator]
 }
 
 # Outputs the url of the service

--- a/ops/cloud/jobs/cleaner/config.json
+++ b/ops/cloud/jobs/cleaner/config.json
@@ -1,5 +1,5 @@
 {
-    "repo" : "${gcp_registry}/${gcp_project}",
+    "repo" : "${gcp_registry}/${gcp_project}/customers",
     "json" : "60s",
     "allow_tagged": true,
     "keep" : 5

--- a/ops/cloud/jobs/destroy.tf
+++ b/ops/cloud/jobs/destroy.tf
@@ -7,12 +7,6 @@ resource "google_cloud_run_service_iam_policy" "destroy_policy" {
   policy_data = data.google_iam_policy.schedule_policy.policy_data
 }
 
-# Gets a reference to the infrastructure service account
-# https://www.terraform.io/docs/providers/google/d/service_account.html
-data "google_service_account" "infrastructure" {
-  account_id = "infrastructure"
-}
-
 # Creates the Cloud Run job for destroying the infrastructure
 # https://www.terraform.io/docs/providers/google/r/cloud_run_service.html
 resource "google_cloud_run_service" "destroy_job" {
@@ -50,6 +44,8 @@ resource "google_cloud_scheduler_job" "destroy_job" {
       service_account_email = google_service_account.schedules_service_account.email
     }
   }
+
+  depends_on = [google_project_iam_member.infrastructure_app_engine_creator]
 }
 
 # Outputs the url of the service

--- a/ops/cloud/jobs/jobs.tf
+++ b/ops/cloud/jobs/jobs.tf
@@ -1,3 +1,34 @@
+locals {
+  region = data.google_client_config.context.region
+}
+
+# Gets a reference to the infrastructure service account
+# https://www.terraform.io/docs/providers/google/d/service_account.html
+data "google_service_account" "infrastructure" {
+  account_id = "infrastructure"
+}
+
+# A customer role is required for creating AppEngine Apps
+# https://www.terraform.io/docs/providers/google/r/google_project_iam_custom_role.html
+resource "google_project_iam_custom_role" "app_engine_creator" {
+  role_id     = "appengine.creator"
+  title       = "AppEngine Creator"
+  description = "Custom role to enable AppEngine creation without 'owner' role"
+  permissions = ["appengine.applications.create"]
+}
+
+# Associates the role to the add user
+resource "google_project_iam_member" "infrastructure_app_engine_creator" {
+  role   = google_project_iam_custom_role.app_engine_creator.id
+  member = "serviceAccount:${data.google_service_account.infrastructure.email}"
+}
+
+# This is REQUIRED to create a container app for the scheduler
+# https://www.terraform.io/docs/providers/google/r/app_engine_application.html
+resource "google_app_engine_application" "scheduler_app" {
+  location_id = local.region
+}
+
 # Creates a service account for jobs
 # https://www.terraform.io/docs/providers/google/r/google_service_account.html
 resource "google_service_account" "schedules_service_account" {

--- a/ops/cloud/services/services.tf
+++ b/ops/cloud/services/services.tf
@@ -66,3 +66,11 @@ resource "google_project_service" "cloud_scheduler" {
   disable_dependent_services = local.disable_dependent_services
   disable_on_destroy         = local.disable_on_destroy
 }
+
+# Enables App Engine - This is REQUIRED by cloud scheduler
+# https://www.terraform.io/docs/providers/google/r/google_project_service.html
+resource "google_project_service" "app_engine" {
+  service                    = "appengine.googleapis.com"
+  disable_dependent_services = local.disable_dependent_services
+  disable_on_destroy         = local.disable_on_destroy
+}


### PR DESCRIPTION
1. Remove syntax that will be depreciated that ignore the cluster cert change
2  Add in an explicit App Engine creation in the required region (container for scheduler
3. Fix App Engine API requirement by enabling in services.tf
4. Add back in the full repo path